### PR TITLE
Add HOTA metrics

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,9 @@
 name: CI
-on: [push, pull_request]
+on: 
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   test_and_lint:

--- a/src/evaldet/metrics.py
+++ b/src/evaldet/metrics.py
@@ -47,7 +47,11 @@ def compute_mot_metrics(
             - IDFN (ID false negatives)
             - IDTP (ID true positives)
 
-        - HOTA metrics (both average and individual alpha values)
+        - HOTA metrics (both average and individual alpha values). Note that I use
+          the matching algorithm from the paper, which differs from what the official
+          repository (TrackEval) is using - see
+          `this issue <https://github.com/JonathonLuiten/TrackEval/issues/22>`__
+          for more details
 
             - HOTA
             - AssA

--- a/src/evaldet/mot_metrics/hota.py
+++ b/src/evaldet/mot_metrics/hota.py
@@ -1,0 +1,89 @@
+from typing import Dict, Union
+
+import numpy as np
+from scipy.optimize import linear_sum_assignment  # type: ignore
+
+from ..dist import iou_dist
+from ..tracks import Tracks
+
+_EPS = 1 / 1000
+
+
+def calculate_hota_metrics(
+    ground_truth: Tracks, hypotheses: Tracks
+) -> Dict[str, Union[float, np.ndarray]]:
+
+    gts = tuple(ground_truth.ids_count.keys())
+    gts_counts = tuple(ground_truth.ids_count.values())
+    hyps = tuple(hypotheses.ids_count.keys())
+    hyps_counts = tuple(hypotheses.ids_count.values())
+    n_gt, n_hyp = len(gts), len(hyps)
+
+    alphas = np.arange(0.05, 0.96, 0.05)  # from 0.05 to 0.95 inclusive
+
+    # The arrays should all have the shape [n_alphas, n_gt, n_hyp]
+    TPA_max = np.zeros((len(alphas), n_gt, n_hyp), dtype=np.int32)
+    FPA_max = np.tile(np.tile(hyps_counts, (n_gt, 1)), (len(alphas), 1, 1))
+    FNA_max = np.tile(np.tile(gts_counts, (n_hyp, 1)).T, (len(alphas), 1, 1))
+
+    TPA, FPA, FNA = TPA_max.copy(), FPA_max.copy(), FNA_max.copy()
+    FP = np.ones((len(alphas),)) * sum(hyps_counts)
+    FN = np.ones((len(alphas),)) * sum(gts_counts)
+    LocAs = np.zeros((len(alphas),))  # Accumulator of similarities
+
+    # Do the optimisitc matching - allow multiple matches per gt/hyp in same frame
+    for frame in sorted(set(ground_truth.frames).intersection(hypotheses.frames)):
+        dist_matrix = iou_dist(
+            ground_truth[frame]["detections"], hypotheses[frame]["detections"]
+        )
+        gt_idx_ids = [gts.index(x) for x in ground_truth[frame]["ids"]]
+        hyp_idx_ids = [hyps.index(x) for x in hypotheses[frame]["ids"]]
+
+        for a_ind in range(len(alphas)):
+            for row_ind, col_ind in np.argwhere(dist_matrix < alphas[a_ind]):
+                TPA_max[a_ind, gt_idx_ids[row_ind], hyp_idx_ids[col_ind]] += 1
+
+    # Compute optimistic A_max, to be used for actual matching
+    A_max = TPA_max / (FNA_max + FPA_max - TPA_max)
+
+    # Do the actual matching
+    for frame in sorted(set(ground_truth.frames).intersection(hypotheses.frames)):
+        dist_matrix = iou_dist(
+            ground_truth[frame]["detections"], hypotheses[frame]["detections"]
+        )
+        gt_idx_ids = [gts.index(x) for x in ground_truth[frame]["ids"]]
+        hyp_idx_ids = [hyps.index(x) for x in hypotheses[frame]["ids"]]
+
+        for a_ind in range(len(alphas)):
+            opt_matrix = ((dist_matrix < alphas[a_ind]) / _EPS).astype(np.float64)
+            opt_matrix += A_max[a_ind][np.ix_(gt_idx_ids, hyp_idx_ids)]
+            opt_matrix += (1 - dist_matrix) * _EPS  # type: ignore
+
+            # Calculate matching as a LAP
+            matching_inds = linear_sum_assignment(opt_matrix, maximize=True)
+            for row_ind, col_ind in zip(*matching_inds):
+                if dist_matrix[row_ind, col_ind] < alphas[a_ind]:
+                    TPA[a_ind, gt_idx_ids[row_ind], hyp_idx_ids[col_ind]] += 1
+                    LocAs[a_ind] += 1 - dist_matrix[row_ind, col_ind]
+
+    # Compute proper scores
+    TP = TPA.sum(axis=(1, 2))
+    A = TPA / (FNA + FPA - TPA)
+    DetAs = TP / (FN + FP - TP)
+    AssAs = (TPA * A).sum(axis=(1, 2)) / np.maximum(TP, 1)
+    HOTAs = np.sqrt(DetAs * AssAs)
+
+    # If no matches -> full similarity [strange default]
+    LocAs = np.maximum(LocAs, 1e-10) / np.maximum(TP, 1e-10)
+
+    return {
+        "HOTA": HOTAs.mean(),
+        "DetA": DetAs.mean(),
+        "AssA": AssAs.mean(),
+        "LocA": LocAs.mean(),
+        "alphas_HOTA": alphas,
+        "HOTA_alpha": HOTAs,
+        "DetA_alpha": DetAs,
+        "AssA_alpha": AssAs,
+        "LocA_alpha": LocAs,
+    }

--- a/src/evaldet/mot_metrics/identity.py
+++ b/src/evaldet/mot_metrics/identity.py
@@ -10,7 +10,6 @@ from ..tracks import Tracks
 def calculate_id_metrics(
     ground_truth: Tracks, hypotheses: Tracks, dist_threshold: float = 0.5
 ) -> Dict[str, Union[float, int]]:
-    pass
 
     gts = tuple(ground_truth.ids_count.keys())
     gts_counts = tuple(ground_truth.ids_count.values())

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -2,7 +2,20 @@ import numpy as np
 
 from evaldet import Tracks, compute_mot_metrics
 
-_TUD_METRICS = ("MOTA", "MOTP", "FP_CLEAR", "FN_CLEAR", "IDS", "IDP", "IDR", "IDF1")
+_TUD_METRICS = (
+    "MOTA",
+    "MOTP",
+    "FP_CLEAR",
+    "FN_CLEAR",
+    "IDS",
+    "IDP",
+    "IDR",
+    "IDF1",
+    "HOTA",
+    "DetA",
+    "AssA",
+    "LocA",
+)
 
 
 def test_tud_campus():
@@ -19,10 +32,28 @@ def test_tud_campus():
         "IDP": 0.730,
         "IDR": 0.451,
         "IDF1": 0.558,
+        "HOTA": 0.393,  # Does not correspond exactly to iriginal
+        "DetA": 0.425,  # Does not correspond exactly to iriginal
+        "AssA": 0.365,  # Does not correspond exactly to iriginal
+        "LocA": 0.768,  # Does not correspond exactly to iriginal
     }
 
     for key in results:
         np.testing.assert_array_almost_equal(results[key], exp_results[key], decimal=3)
+
+    # Check that the results are similar to those obtained with TrackEval
+    # Note that they will never be the same, since a different algorithm
+    # is used for matching. Nevertheless, it's a good idea to check that
+    # we do not get widely different results
+    orig_hota_results = {
+        "HOTA": 0.3914,
+        "DetA": 0.4181,
+        "AssA": 0.3691,
+        "LocA": 0.7701,
+    }
+
+    for key, orig_val in orig_hota_results.items():
+        np.testing.assert_array_almost_equal(results[key], orig_val, decimal=2)
 
 
 def test_tud_stadtmitte():
@@ -39,8 +70,25 @@ def test_tud_stadtmitte():
         "IDP": 0.820,
         "IDR": 0.531,
         "IDF1": 0.645,
+        "HOTA": 0.399,  # Does not correspond exactly to iriginal
+        "DetA": 0.399,  # Does not correspond exactly to iriginal
+        "AssA": 0.404,  # Does not correspond exactly to iriginal
+        "LocA": 0.733,  # Does not correspond exactly to iriginal
     }
 
-    print(results)
     for key in results:
         np.testing.assert_array_almost_equal(results[key], exp_results[key], decimal=3)
+
+    # Check that the results are similar to those obtained with TrackEval
+    # Note that they will never be the same, since a different algorithm
+    # is used for matching. Nevertheless, it's a good idea to check that
+    # we do not get widely different results
+    orig_hota_results = {
+        "HOTA": 0.3979,
+        "DetA": 0.3923,
+        "AssA": 0.4085,
+        "LocA": 0.7375,
+    }
+
+    for key, orig_val in orig_hota_results.items():
+        np.testing.assert_array_almost_equal(results[key], orig_val, decimal=2)

--- a/tests/unit/test_hota.py
+++ b/tests/unit/test_hota.py
@@ -1,0 +1,175 @@
+import numpy as np
+
+from evaldet import Tracks
+from evaldet.mot_metrics.hota import calculate_hota_metrics
+
+
+def test_hyp_missing_frame():
+    gt = Tracks()
+    gt.add_frame(0, [0], np.array([[0, 0, 1, 1]]))
+    gt.add_frame(1, [0], np.array([[0, 0, 1, 1]]))
+
+    hyp = Tracks()
+    hyp.add_frame(0, [0], np.array([[0, 0, 1, 1]]))
+    metrics = calculate_hota_metrics(gt, hyp)
+
+    assert metrics["DetA"] == 0.5
+    assert metrics["AssA"] == 0.5
+    assert metrics["HOTA"] == 0.5
+    assert metrics["LocA"] == 1.0
+    for m in ["HOTA_alpha", "AssA_alpha", "DetA_alpha", "LocA_alpha"]:
+        assert metrics[m].var() == 0
+
+
+def test_gt_missing_frame():
+    gt = Tracks()
+    gt.add_frame(0, [0], np.array([[0, 0, 1, 1]]))
+
+    hyp = Tracks()
+    hyp.add_frame(0, [0], np.array([[0, 0, 1, 1]]))
+    hyp.add_frame(1, [0], np.array([[0, 0, 1, 1]]))
+    metrics = calculate_hota_metrics(gt, hyp)
+
+    assert metrics["DetA"] == 0.5
+    assert metrics["AssA"] == 0.5
+    assert metrics["HOTA"] == 0.5
+    assert metrics["LocA"] == 1.0
+    for m in ["HOTA_alpha", "AssA_alpha", "DetA_alpha", "LocA_alpha"]:
+        assert metrics[m].var() == 0
+
+
+def test_no_matches():
+    gt = Tracks()
+    gt.add_frame(0, [0], np.array([[0, 0, 1, 1]]))
+
+    hyp = Tracks()
+    hyp.add_frame(0, [0], np.array([[1, 1, 2, 2]]))
+    metrics = calculate_hota_metrics(gt, hyp)
+
+    assert metrics["DetA"] == 0
+    assert metrics["AssA"] == 0
+    assert metrics["HOTA"] == 0
+    assert metrics["LocA"] == 1.0
+    for m in ["HOTA_alpha", "AssA_alpha", "DetA_alpha", "LocA_alpha"]:
+        assert metrics[m].var() == 0
+
+
+def test_alphas():
+    gt = Tracks()
+    gt.add_frame(0, [0, 1], np.array([[0, 0, 1, 1], [1, 1, 2, 2]]))
+
+    hyp = Tracks()
+    hyp.add_frame(0, [0, 1], np.array([[0.1, 0.1, 1.1, 1.1], [1.2, 1.2, 2.2, 2.2]]))
+    metrics = calculate_hota_metrics(gt, hyp)
+
+    np.testing.assert_almost_equal(metrics["AssA"], 0.6842105263157, 5)
+    np.testing.assert_almost_equal(metrics["DetA"], 0.5438596491228, 5)
+    np.testing.assert_almost_equal(metrics["HOTA"], 0.5952316356188, 5)
+    np.testing.assert_almost_equal(metrics["LocA"], 0.7317558602388, 5)
+
+    for a_ind, alpha in enumerate(metrics["alphas"]):
+        if alpha < 0.31932773:
+            assert metrics["HOTA_alpha"][a_ind] == 0
+            assert metrics["AssA_alpha"][a_ind] == 0
+            assert metrics["DetA_alpha"][a_ind] == 0
+            assert metrics["LocA_alpha"][a_ind] == 1.0
+        elif 0.52941176 > alpha >= 0.31932773:
+            assert metrics["HOTA_alpha"][a_ind] == np.sqrt(1 / 3)
+            assert metrics["AssA_alpha"][a_ind] == 1.0
+            assert metrics["DetA_alpha"][a_ind] == 1 / 3
+            np.testing.assert_almost_equal(
+                metrics["LocA_alpha"][a_ind], 1 - 0.31932773, 5
+            )
+        else:
+            assert metrics["HOTA_alpha"][a_ind] == 1
+            assert metrics["AssA_alpha"][a_ind] == 1.0
+            assert metrics["DetA_alpha"][a_ind] == 1
+            np.testing.assert_almost_equal(
+                metrics["LocA_alpha"][a_ind], 1 - (0.31932773 + 0.52941176) / 2, 5
+            )
+
+
+def test_priority_matching_1():
+    pass
+
+
+def test_priority_matching_2():
+    pass
+
+
+def test_example_1a():
+    """Example A from figure 1 in the paper"""
+    gt = Tracks()
+    for i in range(20):
+        gt.add_frame(i, [0], np.array([[0, 0, 1, 1]]))
+
+    hyp = Tracks()
+    for i in range(10):
+        hyp.add_frame(i, [0], np.array([[0, 0, 1, 1]]))
+    metrics = calculate_hota_metrics(gt, hyp)
+
+    assert metrics["HOTA"] == 0.5
+    assert metrics["AssA"] == 0.5
+    assert metrics["DetA"] == 0.5
+    assert metrics["LocA"] == 1.0
+
+
+def test_example_1b():
+    """Example B from figure 1 in the paper"""
+    gt = Tracks()
+    for i in range(20):
+        gt.add_frame(i, [0], np.array([[0, 0, 1, 1]]))
+
+    hyp = Tracks()
+    for i in range(7):
+        hyp.add_frame(i, [0], np.array([[0, 0, 1, 1]]))
+
+    for i in range(7, 14):
+        hyp.add_frame(i, [1], np.array([[0, 0, 1, 1]]))
+    metrics = calculate_hota_metrics(gt, hyp)
+
+    np.testing.assert_array_almost_equal(metrics["HOTA"], 0.5, 2)
+    np.testing.assert_array_almost_equal(metrics["AssA"], 0.35, 2)
+    np.testing.assert_array_almost_equal(metrics["DetA"], 0.70, 2)
+    assert metrics["LocA"] == 1.0
+
+
+def test_example_1c():
+    """Example C from figure 1 in the paper"""
+    gt = Tracks()
+    for i in range(20):
+        gt.add_frame(i, [0], np.array([[0, 0, 1, 1]]))
+
+    hyp = Tracks()
+    for i in range(5):
+        hyp.add_frame(i, [0], np.array([[0, 0, 1, 1]]))
+
+    for i in range(5, 10):
+        hyp.add_frame(i, [1], np.array([[0, 0, 1, 1]]))
+
+    for i in range(10, 15):
+        hyp.add_frame(i, [2], np.array([[0, 0, 1, 1]]))
+
+    for i in range(15, 20):
+        hyp.add_frame(i, [3], np.array([[0, 0, 1, 1]]))
+    metrics = calculate_hota_metrics(gt, hyp)
+
+    np.testing.assert_array_almost_equal(metrics["HOTA"], 0.5, 2)
+    np.testing.assert_array_almost_equal(metrics["AssA"], 0.25, 2)
+    np.testing.assert_array_almost_equal(metrics["DetA"], 1, 2)
+    assert metrics["LocA"] == 1.0
+
+
+def test_simple_case():
+    """Test a simple case with 3 frames and 2 detections/gts per frame."""
+    gt = Tracks()
+    gt.add_frame(0, [0, 1], np.array([[0, 0, 1, 1], [1, 1, 2, 2]]))
+    gt.add_frame(1, [0, 1], np.array([[0, 0, 1, 1], [2, 2, 3, 3]]))
+    gt.add_frame(2, [0, 1], np.array([[0, 0, 1, 1], [2, 2, 3, 3]]))
+
+    hyp = Tracks()
+    hyp.add_frame(0, [0, 1], np.array([[0, 0, 1, 1], [1, 1, 2, 2]]))
+    hyp.add_frame(1, [0, 1], np.array([[0.1, 0.1, 1.1, 1.1], [1, 1, 2, 2]]))
+    hyp.add_frame(2, [2, 1], np.array([[0.05, 0.05, 1.05, 1.05], [2, 2, 3, 3]]))
+
+    # metrics = calculate_hota_metrics(gt, hyp)

--- a/tests/unit/test_hota.py
+++ b/tests/unit/test_hota.py
@@ -67,7 +67,7 @@ def test_alphas():
     np.testing.assert_almost_equal(metrics["HOTA"], 0.5952316356188, 5)
     np.testing.assert_almost_equal(metrics["LocA"], 0.7317558602388, 5)
 
-    for a_ind, alpha in enumerate(metrics["alphas"]):
+    for a_ind, alpha in enumerate(metrics["alphas_HOTA"]):
         if alpha < 0.31932773:
             assert metrics["HOTA_alpha"][a_ind] == 0
             assert metrics["AssA_alpha"][a_ind] == 0


### PR DESCRIPTION
This adds HOTA metrics - but using the matching algorithm from the paper, not the one in TrackEval repository - see https://github.com/JonathonLuiten/TrackEval/issues/22

The resulting metrics (on the two integration tests so far) are actually pretty similar, it seems that my implementation actually gives higher results (see integration tests).

When more integration tests are added it will become clearer what exactly the differences are.